### PR TITLE
fix: uid doesn't exist on channel object

### DIFF
--- a/src/save_alert_channels.py
+++ b/src/save_alert_channels.py
@@ -23,7 +23,7 @@ def get_all_alert_channels_in_grafana():
         return []
     
 def save_alert_channel(channel_name, file_name, alert_channel_setting):
-    file_path = folder_path + '/' + file_name + '.alert_channel'
+    file_path = folder_path + '/' + str(file_name) + '.alert_channel'
     with open(file_path, 'w') as f:
         f.write(json.dumps(alert_channel_setting))
     print("alert_channel:{0} is saved to {1}".format(channel_name, file_path))
@@ -32,12 +32,12 @@ def get_indivisual_alert_channel_and_save(channels):
     for channel in channels:
         save_alert_channel(
             to_python2_and_3_compatible_string(channel['name']),
-            channel['uid'],
+            to_python2_and_3_compatible_string(channel['id']),
             channel
         )
         file_path = folder_path + '/' + log_file
         with open(u"{0}".format(file_path) , 'w+') as f:
-            f.write('{}\t{}'.format(channel['uid'], to_python2_and_3_compatible_string(channel['name'])))
+            f.write('{}\t{}'.format(to_python2_and_3_compatible_string(channel['id']), to_python2_and_3_compatible_string(channel['name'])))
 
 
 alert_channels = get_all_alert_channels_in_grafana()


### PR DESCRIPTION
Not sure if this is happening to everybody by my alert object doesn't have `uid` and I was getting the following error:

```
Traceback (most recent call last):
  File "/Users/israel/Desktop/grafana-backup-tool/src/save_alert_channels.py", line 44, in <module>
    get_indivisual_alert_channel_and_save(alert_channels)
  File "/Users/israel/Desktop/grafana-backup-tool/src/save_alert_channels.py", line 35, in get_indivisual_alert_channel_and_save
    channel['uid'],
KeyError: 'uid'
```

The following PR fix that by using the `id` instead